### PR TITLE
Uses 'six' compatibility library and revises 'stashward.handler' to expl...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.2] - 2015-04-27
+### Added
+- Python 2 compatibility when unicode (text) data is emitted.
+
 ## [0.1.1] - 2015-03-11
 ### Added
 - Everything

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 # do some feature detection to see what extra packages need to be installed
-install_requires = []
+install_requires = ['six']
 try:
     from ssl import match_hostname, CertificateError
 except ImportError:
@@ -16,7 +16,7 @@ except AttributeError:
 
 setup(
     name="stashward",
-    version='0.1.1',
+    version='0.1.2',
     author='Matt Johnson',
     author_email='mdj2@pdx.edu',
     description="A log formatter and handler for Python that implements the (poorly specified) logstash-forwarder protocol.",


### PR DESCRIPTION
...icitly mark bytestrings.

These changes provide Python 2 compatibility in cases where non-ASCII text data is emitted.
